### PR TITLE
[IMP] server_action_mass_edit: rename mass editing line table and model t#71297

### DIFF
--- a/server_action_mass_edit/migrations/17.0.1.0.0/pre-migration.py
+++ b/server_action_mass_edit/migrations/17.0.1.0.0/pre-migration.py
@@ -1,0 +1,16 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    cr = env.cr
+
+    if not openupgrade.table_exists(cr, "mass_editing_line"):
+        return
+
+    openupgrade.rename_models(
+        cr, [("mass.editing.line", "ir.actions.server.mass.edit.line")]
+    )
+    openupgrade.rename_tables(
+        cr, [("mass_editing_line", "ir_actions_server_mass_edit_line")]
+    )


### PR DESCRIPTION
Add a migration script to rename the mass editing line table and model to match the new ones defined in the module.